### PR TITLE
Pryr removed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: HuBMAPR
 Title: Interface to 'HuBMAP'
-Version: 1.5.0
+Version: 1.5.1
 Authors@R:
     c(person(
         given = "Christine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     ggplot2,
     rmarkdown,
     BiocStyle,
-    pryr
+    lobstr
 VignetteBuilder: knitr
 biocViews: Software, SingleCell, DataImport, ThirdPartyClient, Spatial, 
     Infrastructure

--- a/vignettes/hubmapr_vignettes.Rmd
+++ b/vignettes/hubmapr_vignettes.Rmd
@@ -140,8 +140,8 @@ conduct data wrangling and specific information extraction.
 library("dplyr")
 library("tidyr")
 library("ggplot2")
+library("lobstr")
 library("HuBMAPR")
-library("pryr")
 ```
 
 ## Data Discovery
@@ -165,7 +165,7 @@ Using corresponding functions to explore entity data.
 system.time({
     datasets_df <- datasets()
 })
-object_size(datasets_df)
+lobstr::obj_size(datasets_df)
 
 datasets_df
 ```


### PR DESCRIPTION
pryr got removed from CRAN, functionality superseded in this case via lobstr - pryr::object_size -> lobstr::obj_size

Ref: https://stat.ethz.ch/pipermail/bioc-devel/2026-April/021345.html

